### PR TITLE
Fix ability to change cluster colors

### DIFF
--- a/klustaviewa/control/controller.py
+++ b/klustaviewa/control/controller.py
@@ -155,7 +155,7 @@ class Controller(object):
             _description='Split2')
         
     def change_cluster_color(self, cluster, color):
-        color_old = self.loader.get_cluster_colors(cluster)
+        color_old = self.loader.get_cluster_color(cluster) # Sven edit self.loader.get_cluster_colors(cluster) removed s
         color_new = color
         clusters_selected = self.loader.get_clusters_selected()
         return self._process('change_cluster_color', cluster, color_old, 
@@ -188,7 +188,7 @@ class Controller(object):
         
     def remove_group(self, group):
         name = self.loader.get_group_names(group)
-        color = self.loader.get_group_colors(group)
+        color = None # Sven changed because group color is giving errors
         return self._process('remove_group', group, name, color, 
             _description='Removed group {0:s}'.format(get_pretty_arg(group)))
         

--- a/klustaviewa/views/viewdata.py
+++ b/klustaviewa/views/viewdata.py
@@ -39,10 +39,15 @@ def get_waveformview_data(exp, clusters=[], channel_group=0, clustering='main',
     # spikes_selected = get_some_spikes_in_clusters(clusters, spike_clusters)
 
     # cluster_colors = clusters_data.color[clusters]
+    # get colors from application data:
     cluster_colors = pd.Series([
-        next_color(cl)
+        (clusters_data[cl].application_data.klustaviewa.color or 1)
             if cl in clusters_data else 1
                            for cl in clusters], index=clusters)
+    # cluster_colors = pd.Series([
+    #     next_color(cl)
+    #         if cl in clusters_data else 1
+    #                        for cl in clusters], index=clusters)
 
     if spikes_data.waveforms_filtered is None:
 
@@ -129,10 +134,15 @@ def get_featureview_data(exp, clusters=[], channel_group=0, clustering='main',
 
     spike_clusters = getattr(spikes_data.clusters, clustering)[:]
     # cluster_colors = clusters_data.color[clusters]
+    # get colors from application data:
     cluster_colors = pd.Series([
-        next_color(cl)
+        (clusters_data[cl].application_data.klustaviewa.color or 1)
             if cl in clusters_data else 1
                            for cl in clusters], index=clusters)
+    # cluster_colors = pd.Series([
+    #     next_color(cl)
+    #         if cl in clusters_data else 1
+    #                        for cl in clusters], index=clusters)
 
     if len(clusters) > 0:
         # TODO: put fraction in user parameters
@@ -249,10 +259,18 @@ def get_clusterview_data(exp, statscache=None, channel_group=0,
     #                            for cl in clusters], index=clusters)
     # Make sure there's no crash if this is called before the clusters had a chance
     # to be added in the HDF5 file.
+
+    # get colors from application data:
     cluster_colors = pd.Series([
-        next_color(cl)
+        (clusters_data[cl].application_data.klustaviewa.color or 1)
             if cl in clusters_data else 1
                            for cl in clusters], index=clusters)
+
+    # cluster_colors = pd.Series([
+    #     next_color(cl)
+    #         if cl in clusters_data else 1
+    #                        for cl in clusters], index=clusters)
+
     cluster_groups = pd.Series([
         (clusters_data[cl].cluster_group
                                 if clusters_data[cl].cluster_group is not None else 3)
@@ -270,13 +288,28 @@ def get_clusterview_data(exp, statscache=None, channel_group=0,
     sizes = np.bincount(spike_clusters)
     cluster_sizes = pd.Series(sizes[clusters], index=clusters)
 
+
+    # Get the cluster, spike and channel data
+    clusters_data = getattr(exp.channel_groups[0].clusters, clustering)
+    spikes_data = exp.channel_groups[channel_group].spikes
+    channels_data = exp.channel_groups[channel_group].channels
+
+    # Get some spike variables
+    nchannels = spikes_data.nchannels
+    sample_rate = exp.application_data.spikedetekt.sample_rate
+    spike_clusters = getattr(spikes_data.clusters, clustering)[:]
+    spiketimes_all = spikes_data.concatenated_time_samples[:]
+
+    
     data = dict(
         cluster_colors=cluster_colors,
         cluster_groups=cluster_groups,
         group_colors=group_colors,
         group_names=group_names,
-        cluster_sizes=cluster_sizes,
+        cluster_sizes=cluster_sizes, 
+
     )
+
     if statscache is not None:
         data['cluster_quality'] = statscache.cluster_quality
     return data
@@ -292,10 +325,17 @@ def get_correlogramsview_data(exp, correlograms, clusters=[],
 
     # cluster_colors = clusters_data.color[clusters]
     # cluster_colors = pandaize(cluster_colors, clusters)
+
+    # get colors from application data:
     cluster_colors = pd.Series([
-        next_color(cl)
+        (clusters_data[cl].application_data.klustaviewa.color or 1)
             if cl in clusters_data else 1
                            for cl in clusters], index=clusters)
+
+    # cluster_colors = pd.Series([
+    #     next_color(cl)
+    #         if cl in clusters_data else 1
+    #                        for cl in clusters], index=clusters)
 
     # TODO: cache and optimize this
     spike_clusters = getattr(exp.channel_groups[channel_group].spikes.clusters,
@@ -344,8 +384,16 @@ def get_similaritymatrixview_data(exp, matrix=None,
     clusters_data = getattr(exp.channel_groups[channel_group].clusters, clustering)
     cluster_groups_data = getattr(exp.channel_groups[channel_group].cluster_groups, clustering)
     clusters = sorted(clusters_data.keys())
-    cluster_colors = pd.Series([next_color(cl)
+
+    # get colors from application data:
+    cluster_colors = pd.Series([
+        (clusters_data[cl].application_data.klustaviewa.color or 1)
+            if cl in clusters_data else 1
                            for cl in clusters], index=clusters)
+
+    # cluster_colors = pd.Series([next_color(cl)
+    #                        for cl in clusters], index=clusters)
+
     cluster_groups = pd.Series([clusters_data[cl].cluster_group or 0
                                for cl in clusters], index=clusters)
 

--- a/klustaviewa/views/viewdata.py
+++ b/klustaviewa/views/viewdata.py
@@ -288,18 +288,6 @@ def get_clusterview_data(exp, statscache=None, channel_group=0,
     sizes = np.bincount(spike_clusters)
     cluster_sizes = pd.Series(sizes[clusters], index=clusters)
 
-
-    # Get the cluster, spike and channel data
-    clusters_data = getattr(exp.channel_groups[0].clusters, clustering)
-    spikes_data = exp.channel_groups[channel_group].spikes
-    channels_data = exp.channel_groups[channel_group].channels
-
-    # Get some spike variables
-    nchannels = spikes_data.nchannels
-    sample_rate = exp.application_data.spikedetekt.sample_rate
-    spike_clusters = getattr(spikes_data.clusters, clustering)[:]
-    spiketimes_all = spikes_data.concatenated_time_samples[:]
-
     
     data = dict(
         cluster_colors=cluster_colors,


### PR DESCRIPTION
In the new version of klustaviewa released April 2016 the ability to change the colors of clusters did not work. To fix this I added changes to both the klustaviewa repository and the kwiklib repository (which need to be merged both in order for this fix to work). I implemented the way the old klustaviewa worked by getting the cluster color from the kwik file.