### PR TITLE
Conflict Fix for environment-win.yml

### DIFF
--- a/installer/environment-win.yml
+++ b/installer/environment-win.yml
@@ -3,7 +3,7 @@ dependencies:
 - cython=0.23.4=py27_0
 - dateutil=2.4.1=py27_0
 - decorator=4.0.9=py27_0
-- h5py=2.3.1=np18py27_0
+- h5py=2.2.1=np17py27_0
 - hdf5=1.8.15.1=vc9_4
 - ipython=4.1.2=py27_0
 - ipython_genutils=0.1.0=py27_0


### PR DESCRIPTION
Using the old environment file attempts to get ' h5py=2.3.1=np18py27_0 ', this depends on numpy 1.8, however numpy 1.7 is installed using this environment file. This stalls conda.

I was able to generate a working klustaviewa on Windows after making this change.